### PR TITLE
docs(contributing): update contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,9 @@ Please note we have a code of conduct, please follow it in all your interactions
 
 1. Adherence to the  [Developer Certificate of Origin
 (DCO)](https://developercertificate.org/) version 1.1 (`git --signoff`).
-2. Ensure all tests are passing (`npm test`).
-3. Adhere to [standardjs](http://standardjs.com) guidelines.
-4. Add tests for any new features or to show that bugs have been fixed.
-5. Update the README.md with details of changes to the interface.
-6. You may merge the Pull Request in once you have the sign-off of the package owner.
+2. Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
+3. Ensure all tests are passing (`npm test`).
+4. Adhere to [standardjs](http://standardjs.com) guidelines.
+5. Add tests for any new features or to show that bugs have been fixed.
+6. Update the README.md with details of changes to the interface.
+7. You may merge the Pull Request in once you have the sign-off of the package owner.


### PR DESCRIPTION
Add details that all commits must follow the conventional commits standard.