### PR TITLE
[#32] Unflatten Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,41 @@ const underscoreFlat = flatten(original, '_')
 }
 */
 ```
+### unflatten(obj, [delimiter])
+
+Unflats an object back to its original nested form. Optionally takes a custom `delimiter`, otherwise uses `.` by default. Circular references denoted by `[Circular]` are treated as Strings.
+
+``` javascript
+const unflatten = require('safe-flat')
+
+const original = {
+    'a.b.c.0.val': 'one',
+    'a.b.c.1.val': 'two',
+    'a.b.c.2': '[Circular]',
+    'a.b.d': 'three',
+    'a.e': 'four',
+    'a.b.f': '[Circular]'
+}
+
+
+const unflat = unflatten(original)
+
+/*{
+  a:{
+    b:{
+      c:[
+        {
+          val:'one'
+        },
+        {
+          val:'two'
+        },
+        '[Circular]'
+      ],
+      d:'three',
+      f:'[Circular]'
+    },
+    e:'four'
+  }
+}*/
+```

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const isDate = (obj) => {
   return obj instanceof Date
 }
 
-module.exports = (obj, delimiter) => {
+const flatten = (obj, delimiter) => {
   const result = {}
   const seperator = delimiter || defaultDelimiter
 
@@ -33,4 +33,29 @@ module.exports = (obj, delimiter) => {
   flat(obj, [obj])
 
   return result
+}
+
+const unflatten = (obj, delimiter) => {
+  const result = {}
+  const seperator = delimiter || defaultDelimiter
+
+  if (typeof obj !== 'object' || isDate(obj)) return obj
+
+  const unflat = (original) => {
+    Object.keys(original).forEach((key) => {
+      const newKeys = key.split(seperator)
+      newKeys.reduce((o, k, i) => {
+        return o[k] || (o[k] = isNaN(Number(newKeys[i + 1])) ? (newKeys.length - 1 === i ? original[key] : {}) : [])
+      }, result)
+    })
+  }
+
+  unflat(obj)
+
+  return result
+}
+
+module.exports = {
+  flatten,
+  unflatten
 }

--- a/test/flatten.spec.js
+++ b/test/flatten.spec.js
@@ -1,5 +1,5 @@
 const test = require('ava')
-const flatten = require('../src/index.js')
+const { flatten } = require('../src/index.js')
 
 test('it should return a flattened object', (t) => {
   const original = {

--- a/test/unflatten.spec.js
+++ b/test/unflatten.spec.js
@@ -1,0 +1,145 @@
+const test = require('ava')
+const { unflatten } = require('../src/index.js')
+
+test('it should return an unflattened object', (t) => {
+  const original = {
+    'a.b': 1
+  }
+
+  const expected = {
+    a: {
+      b: 1
+    }
+  }
+
+  t.deepEqual(unflatten(original), expected)
+})
+
+test('it should handle nested arrays', (t) => {
+  const original = {
+    'a.0': 0,
+    'a.1': 1
+  }
+
+  const expected = {
+    a: [0, 1]
+  }
+
+  t.deepEqual(unflatten(original), expected)
+})
+
+test('it should handle circular objects', (t) => {
+  const original = {
+    'a.b.c': 'value',
+    'a.b.d': '[Circular]',
+    'a.b.e.g': 'value',
+    'a.b.e.f': '[Circular]',
+    'x.y.z': '[Circular]'
+  }
+
+  const expected = {
+    a: {
+      b: {
+        c: 'value',
+        d: '[Circular]',
+        e: {
+          f: '[Circular]',
+          g: 'value'
+        }
+      }
+    },
+    x: {
+      y: {
+        z: '[Circular]'
+      }
+    }
+  }
+
+  t.deepEqual(unflatten(original), expected)
+})
+
+test('it should use the passed in delimiter', (t) => {
+  const original = {
+    a_b: 1
+  }
+
+  const expected = {
+    a: {
+      b: 1
+    }
+  }
+
+  t.deepEqual(unflatten(original, '_'), expected)
+})
+
+test('it should handle deep nesting', (t) => {
+  const original = {
+    'a.b.c.0.val': 'one',
+    'a.b.c.1.val': 'two',
+    'a.b.c.2': '[Circular]',
+    'a.b.d': 'three',
+    'a.e': 'four',
+    'a.b.f': '[Circular]'
+  }
+
+  const expected = {
+    a: {
+      b: {
+        c: [{
+          val: 'one'
+        }, {
+          val: 'two'
+        },
+        '[Circular]'
+        ],
+        d: 'three',
+        f: '[Circular]'
+      },
+      e: 'four'
+    }
+  }
+  t.deepEqual(unflatten(original), expected)
+})
+
+test('it should do nothing for flat objects', (t) => {
+  const original = {
+    a: 'one',
+    b: 'two'
+  }
+  t.deepEqual(unflatten(original), original)
+})
+
+test('it should return the original value if not an object', (t) => {
+  const original = 'string'
+  t.deepEqual(unflatten(original), original)
+})
+
+test('it should handle date objects', (t) => {
+  const date = new Date()
+
+  t.deepEqual(unflatten(date), date)
+
+  const original = {
+    'a.b.c': date,
+    'a.b.d': 'one',
+    'a.e.f': date,
+    'a.e.g.h': date
+  }
+
+  const expected = {
+    a: {
+      b: {
+        c: date,
+        d: 'one'
+      },
+      e: {
+        f: date,
+        g: {
+          h: date
+        }
+      }
+    }
+  }
+
+  t.deepEqual(unflatten(original), expected)
+})


### PR DESCRIPTION
### :pencil2: Change Description

Add an unflatten function that will take a flattened object and return a nested object.
New version of now exports an object containing both flatten and unflatten functions.

### :link: Relates to Issue

Fixes # 32

### :triangular_flag_on_post: Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :heavy_check_mark: Pull Request Checklist

- [x] Adherence to the  [Developer Certificate of Origin (DCO)](https://developercertificate.org/) version 1.1 (`git --signoff`).
- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Ensure all tests are passing (`npm test`).
- [x] Adhere to [standardjs](http://standardjs.com) guidelines.
- [x] Add tests for any new features or to show that bugs have been fixed.
- [x] Update the README.md with details of changes to the interface.