### PR TITLE
fix(flatten): fixed flatten not handling empty arrays

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,10 @@ const flatten = (obj, delimiter) => {
           }
         })
         stack.push(value)
-        if (typeof value === 'object' && !isDate(value)) {
+
+        if (Array.isArray(value) && value.length === 0) {
+          result[newKey] = value
+        } else if (typeof value === 'object' && !isDate(value)) {
           return flat(value, stack, newKey)
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,12 @@ const flatten = (obj, delimiter) => {
   if (typeof obj !== 'object' || isDate(obj)) return obj
 
   const flat = (original, stack, prev) => {
+    if (!Object.values(original).length) {
+      result[prev] = original
+
+      return original
+    }
+
     Object.entries(original).forEach(([key, value]) => {
       const newKey = prev
         ? prev + seperator + key
@@ -23,9 +29,7 @@ const flatten = (obj, delimiter) => {
         })
         stack.push(value)
 
-        if (Array.isArray(value) && value.length === 0) {
-          result[newKey] = value
-        } else if (typeof value === 'object' && !isDate(value)) {
+        if (typeof value === 'object' && !isDate(value)) {
           return flat(value, stack, newKey)
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const flatten = (obj, delimiter) => {
   if (typeof obj !== 'object' || isDate(obj)) return obj
 
   const flat = (original, stack, prev) => {
-    if (!Object.values(original).length) {
+    if (!Object.values(original).length && prev) {
       result[prev] = original
 
       return original

--- a/test/flatten.spec.js
+++ b/test/flatten.spec.js
@@ -32,6 +32,23 @@ test('It should process an empty array', t => {
   t.deepEqual(flatten(original), expected)
 })
 
+test('It should process an empty object', t => {
+  const original = {
+    a: {},
+    b: 1,
+    c: {
+      d: []
+    }
+  }
+  const expected = {
+    a: {},
+    b: 1,
+    'c.d': []
+  }
+
+  t.deepEqual(flatten(original), expected)
+})
+
 test('it should handle nested arrays', (t) => {
   const original = {
     a: [0, 1]

--- a/test/flatten.spec.js
+++ b/test/flatten.spec.js
@@ -15,6 +15,13 @@ test('it should return a flattened object', (t) => {
   t.deepEqual(flatten(original), expected)
 })
 
+test('It should handle a completely empty object', t => {
+  const original = {}
+  const expected = {}
+
+  t.deepEqual(flatten(original), expected)
+})
+
 test('It should process an empty array', t => {
   const original = {
     a: [],

--- a/test/flatten.spec.js
+++ b/test/flatten.spec.js
@@ -15,6 +15,23 @@ test('it should return a flattened object', (t) => {
   t.deepEqual(flatten(original), expected)
 })
 
+test('It should process an empty array', t => {
+  const original = {
+    a: [],
+    b: 1,
+    c: {
+      d: []
+    }
+  }
+  const expected = {
+    a: [],
+    b: 1,
+    'c.d': []
+  }
+
+  t.deepEqual(flatten(original), expected)
+})
+
 test('it should handle nested arrays', (t) => {
   const original = {
     a: [0, 1]

--- a/test/unflatten.spec.js
+++ b/test/unflatten.spec.js
@@ -15,6 +15,13 @@ test('it should return an unflattened object', (t) => {
   t.deepEqual(unflatten(original), expected)
 })
 
+test('it should handle empty arrays', t => {
+  const original = { a: [], b: 1, 'c.d': [], 'e.0': 1, 'e.1': 2 }
+  const expected = { a: [], b: 1, c: { d: [] }, e: [1, 2] }
+
+  t.deepEqual(unflatten(original), expected)
+})
+
 test('it should handle nested arrays', (t) => {
   const original = {
     'a.0': 0,


### PR DESCRIPTION
Signed-off-by: Dustin Hershman <dustinh17@gmail.com>

### :pencil2: Change Description

This should address the issue with flatten not properly handling empty arrays in an object, I didn't want to get to fancy with it so I left the solution pretty basic

### :link: Relates to Issue

Fixes #39 

### :triangular_flag_on_post: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :heavy_check_mark: Pull Request Checklist

- [x] Adherence to the  [Developer Certificate of Origin (DCO)](https://developercertificate.org/) version 1.1 (`git --signoff`).
- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Ensure all tests are passing (`npm test`).
- [x] Adhere to [standardjs](http://standardjs.com) guidelines.
- [x] Add tests for any new features or to show that bugs have been fixed.
- [x] Update the README.md with details of changes to the interface.